### PR TITLE
Em vez de usar o índice fixo [1], que acessa uma posição específica d…

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -22,7 +22,7 @@ public class TicketMachine {
     public void inserir(int quantia) throws PapelMoedaInvalidaException {
         boolean achou = false;
         for (int i = 0; i < papelMoeda.length && !achou; i++) {
-            if (papelMoeda[1] == quantia) {
+            if (papelMoeda[i] == quantia) {
                 achou = true;
             }
         }


### PR DESCRIPTION
…o array, deveria usar [i], para que ele possa ser percorrido por inteiro, até que a condição seja satisfeita.